### PR TITLE
add confirm phone number  via code when registr

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,14 @@ DATABASE_URL = 'postgresql://postgres.dagdoynnfduqaapfnrej:TC!0207pgDB@aws-0-eu-
 JWT_SECRET = '12345679'
 JWT_ACCESS_TOKEN_TTL = '3m'
 JWT_REFRESH_TOKEN_TTL = '1D'
+
+
+# для варифікації номера телефону користувача при реєстрації
+# мок версія для тестування.
+NODE_ENV=development
+SMS_PROVIDER=mock       
+
+ # prod: twilio
+TWILIO_SID=ACxxxxxxxxxxxxxxxxxxxx
+TWILIO_TOKEN=xxxxxxxxxxxxxxxxxxxx
+TWILIO_FROM=+1XXXXXXXXXX

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "twilio": "^5.8.0",
     "typeorm": "^0.3.24"
   },
   "devDependencies": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,8 @@ import { SellersModule } from "./modules/sellers/sellers.module";
 import { ProductsModule } from "./modules/products/products.module";
 import { CategoriesModule } from "./modules/categories/categories.module";
 import { SubcategoriesModule } from "./modules/subcategories/subcategories.module";
+import { OtpModule } from "./modules/otp/otp.module";
+
 
 @Module({
   imports: [
@@ -24,7 +26,8 @@ import { SubcategoriesModule } from "./modules/subcategories/subcategories.modul
     SellersModule,
     ProductsModule,
     CategoriesModule,
-    SubcategoriesModule
+    SubcategoriesModule,
+    OtpModule
   ],
   controllers: [AppController],
   providers: [AppService]

--- a/src/modules/otp/otp.controller.ts
+++ b/src/modules/otp/otp.controller.ts
@@ -1,0 +1,26 @@
+// otp/otp.controller.ts
+import { Body, Controller, Post } from '@nestjs/common';
+// import { SendOtpDto } from './dto/send-otp.dto';
+import { SendOtpDto } from '../users/dtos/send-otp.dto';
+// import { VerifyOtpDto } from './dto/verify-otp.dto';
+import { VerifyOtpDto } from '../users/dtos/verify-otp.dto';
+import { OtpService } from './otp.service';
+
+@Controller('auth/phone')
+export class OtpController {
+  constructor(private otp: OtpService) {}
+
+  @Post('send')
+  send(@Body() dto: SendOtpDto) {
+    return this.otp.send(dto.phone); // у dev поверне { devHint: '000000' }
+  }
+
+  @Post('verify')
+  async verify(@Body() dto: VerifyOtpDto) {
+    const res = await this.otp.verify(dto.phone, dto.code);
+    if (!res.ok) return { ok:false, reason:res.reason };
+    
+    await this.otp.markPhoneAsValidated(dto.phone);
+    return { ok:true };
+  }
+}

--- a/src/modules/otp/otp.module.ts
+++ b/src/modules/otp/otp.module.ts
@@ -1,0 +1,24 @@
+// src/modules/otp/otp.module.ts
+import { Module } from '@nestjs/common';
+import { SMS_PROVIDER } from '../sms/sms.provider';
+import { TwilioSmsProvider } from '../sms/twilio.provider';
+import { MockSmsProvider } from '../sms/mock.provider';
+import { OtpService } from './otp.service';
+import { OtpStore } from './otp.store';
+import { OtpController } from './otp.controller';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [UsersModule],
+  controllers: [OtpController],
+  providers: [
+    OtpService,
+    OtpStore,
+    {
+      provide: SMS_PROVIDER,
+      useClass: process.env.NODE_ENV === 'development' ? MockSmsProvider : TwilioSmsProvider,
+    },
+  ],
+  exports: [SMS_PROVIDER, OtpService],
+})
+export class OtpModule {}

--- a/src/modules/otp/otp.service.ts
+++ b/src/modules/otp/otp.service.ts
@@ -1,0 +1,40 @@
+
+import { Injectable, Inject } from '@nestjs/common';
+import { SmsProvider, SMS_PROVIDER } from '../sms/sms.provider';
+import { OtpStore } from './otp.store';
+import { UsersService } from '../users/users.service';
+
+@Injectable()
+export class OtpService {
+  constructor(
+    @Inject(SMS_PROVIDER) private sms: SmsProvider, 
+    private store: OtpStore,
+    private usersService: UsersService
+  ) {}
+
+  private genCode() { return Math.floor(100000 + Math.random()*900000).toString(); }
+
+  async send(phone: string) {
+    const ok = this.store.canSend(phone);
+    if (!ok.ok) throw new Error(ok.reason);
+    const code = process.env.NODE_ENV === 'development' ? '000000' : this.genCode();
+    this.store.set(phone, code);
+    await this.sms.sendOtp(phone, code);
+    return { 
+      ok: true,
+      devHint: process.env.NODE_ENV === 'development' ? code : undefined 
+    };
+  }
+
+  async verify(phone: string, code: string) {
+    const res = this.store.verify(phone, code);
+    return res;
+  }
+
+  async markPhoneAsValidated(phone: string) {
+    const user = await this.usersService.findByPhone(phone);
+    if (user) {
+      await this.usersService.update(user.id, { isPhoneValidated: true });
+    }
+  }
+}

--- a/src/modules/otp/otp.store.ts
+++ b/src/modules/otp/otp.store.ts
@@ -1,0 +1,43 @@
+
+import * as crypto from 'crypto';
+
+type Rec = { hash: string; expiresAt: number; resendAt: number; attempts: number; sentToday: number; day: string; };
+export class OtpStore {
+  private data = new Map<string, Rec>();
+  private hash(code: string) { return crypto.createHash('sha256').update(code).digest('hex'); }
+
+  set(phone: string, code: string, ttlSec = 300) {
+    const day = new Date().toISOString().slice(0,10);
+    const rec = this.data.get(phone);
+    const base: Rec = rec ?? { hash:'', expiresAt:0, resendAt:0, attempts:0, sentToday:0, day };
+    if (base.day !== day) { base.sentToday = 0; base.day = day; }
+    base.hash = this.hash(code);
+    base.expiresAt = Date.now() + ttlSec*1000;
+    base.resendAt = Date.now() + 60*1000; // антиспам: 60с між повторними відправками
+    base.attempts = 0;
+    base.sentToday += 1;
+    this.data.set(phone, base);
+  }
+
+  canSend(phone: string) {
+    const rec = this.data.get(phone);
+    const day = new Date().toISOString().slice(0,10);
+    if (!rec) return { ok: true };
+    const limitPerDay = 5;
+    if (rec.day !== day) return { ok: true };
+    if (Date.now() < rec.resendAt) return { ok: false, reason: 'Wait before resend' };
+    if (rec.sentToday >= limitPerDay) return { ok: false, reason: 'Daily limit' };
+    return { ok: true };
+  }
+
+  verify(phone: string, code: string) {
+    const rec = this.data.get(phone);
+    if (!rec) return { ok: false, reason: 'No code' };
+    if (Date.now() > rec.expiresAt) return { ok: false, reason: 'Expired' };
+    rec.attempts += 1;
+    if (rec.attempts > 5) return { ok: false, reason: 'Too many attempts' };
+    const match = rec.hash === this.hash(code);
+    if (match) this.data.delete(phone);
+    return { ok: match, reason: match ? undefined : 'Wrong code' };
+  }
+}

--- a/src/modules/sms/mock.provider.ts
+++ b/src/modules/sms/mock.provider.ts
@@ -1,0 +1,6 @@
+import { SmsProvider } from './sms.provider';
+export class MockSmsProvider implements SmsProvider {
+  async sendOtp(phone: string, code: string) {
+    console.log(`[MOCK SMS] to ${phone}: code=${code}`);
+  }
+}

--- a/src/modules/sms/sms.provider.ts
+++ b/src/modules/sms/sms.provider.ts
@@ -1,0 +1,5 @@
+export interface SmsProvider {
+  sendOtp(phone: string, code: string): Promise<void>;
+}
+
+export const SMS_PROVIDER = Symbol('SMS_PROVIDER');

--- a/src/modules/sms/twilio.provider.ts
+++ b/src/modules/sms/twilio.provider.ts
@@ -1,0 +1,16 @@
+// src/modules/sms/twilio.provider.ts
+import { Twilio } from 'twilio';
+import { SmsProvider } from './sms.provider';
+
+export class TwilioSmsProvider implements SmsProvider {
+  private client = new Twilio(process.env.TWILIO_SID!, process.env.TWILIO_TOKEN!);
+  private from = process.env.TWILIO_FROM!;
+
+  async sendOtp(phone: string, code: string): Promise<void> {
+    await this.client.messages.create({
+      from: this.from,
+      to: phone,
+      body: `Your verification code: ${code}`,
+    });
+  }
+}

--- a/src/modules/users/dtos/create-user.dto.ts
+++ b/src/modules/users/dtos/create-user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsEmail, IsNotEmpty, IsString, Length, Matches } from "class-validator";
+import { IsEmail, IsNotEmpty, IsString, Length, Matches, IsOptional, IsBoolean } from "class-validator";
 
 export class CreateUserDto {
   @ApiProperty({ description: "User's first name", example: "Василь" })
@@ -25,4 +25,8 @@ export class CreateUserDto {
   // @IsStrongPassword()
   @Length(6, 20)
   password: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPhoneValidated?: boolean;
 }

--- a/src/modules/users/dtos/send-otp.dto.ts
+++ b/src/modules/users/dtos/send-otp.dto.ts
@@ -1,0 +1,6 @@
+import { Matches } from 'class-validator';
+export class SendOtpDto { 
+  @Matches(/^\+\d{10,15}$/, { message: "Phone must be in international format" })
+  phone!: string; 
+}
+

--- a/src/modules/users/dtos/update-user.dto.ts
+++ b/src/modules/users/dtos/update-user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
-import { IsDate, IsEmail, IsString, IsOptional } from "class-validator";
+import { IsDate, IsEmail, IsString, IsOptional, IsBoolean } from "class-validator";
 
 export class UpdateUsersDto {
   @ApiPropertyOptional({ description: "User's first name", example: "Василь" })
@@ -36,4 +36,8 @@ export class UpdateUsersDto {
   @IsOptional()
   @IsString()
   password?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isPhoneValidated?: boolean;
 }

--- a/src/modules/users/dtos/verify-otp.dto.ts
+++ b/src/modules/users/dtos/verify-otp.dto.ts
@@ -1,0 +1,6 @@
+import { Matches, Length } from 'class-validator';
+export class VerifyOtpDto {
+  @Matches(/^\+\d{10,15}$/, { message: "Phone must be in international format" })
+  phone!: string;
+  @Length(6, 6) code!: string;
+}

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -29,6 +29,10 @@ export class UsersService {
     return this.usersRepo.findOne({ where: { email } });
   }
 
+  findByPhone(phone: string) {
+    return this.usersRepo.findOne({ where: { phone } });
+  }
+
   findById(id: string) {
     return this.usersRepo.findOne({ where: { id } });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,6 +1972,13 @@ acorn@^8.11.0, acorn@^8.14.0, acorn@^8.15.0, acorn@^8.4.1:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv-formats@3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz"
@@ -2126,6 +2133,15 @@ aws-ssl-profiles@^1.1.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz"
   integrity sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==
+
+axios@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
+  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 b4a@^1.6.4:
   version "1.6.7"
@@ -2683,12 +2699,12 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-dayjs@^1.11.13:
+dayjs@^1.11.13, dayjs@^1.11.9:
   version "1.11.13"
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz"
   integrity sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
   version "4.4.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -3306,6 +3322,11 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
+follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
 foreground-child@^3.1.0:
   version "3.3.1"
   resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz"
@@ -3341,6 +3362,17 @@ form-data@^4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz"
   integrity sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -3614,6 +3646,14 @@ http2-wrapper@^2.1.10:
   dependencies:
     quick-lru "^5.1.1"
     resolve-alpn "^1.2.0"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -4294,7 +4334,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonwebtoken@9.0.2, jsonwebtoken@^9.0.0:
+jsonwebtoken@9.0.2, jsonwebtoken@^9.0.0, jsonwebtoken@^9.0.2:
   version "9.0.2"
   resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
   integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
@@ -5137,6 +5177,11 @@ proxy-addr@^2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
@@ -5147,7 +5192,7 @@ pure-rand@^6.0.0:
   resolved "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz"
   integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
-qs@^6.11.0, qs@^6.14.0:
+qs@^6.11.0, qs@^6.14.0, qs@^6.9.4:
   version "6.14.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz"
   integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
@@ -5341,6 +5386,11 @@ schema-utils@^4.3.0:
     ajv "^8.9.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
+
+scmp@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/scmp/-/scmp-2.1.0.tgz#37b8e197c425bdeb570ab91cc356b311a11f9c9a"
+  integrity sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==
 
 seek-bzip@^2.0.0:
   version "2.0.0"
@@ -5921,6 +5971,19 @@ tslib@2.8.1, tslib@^2.1.0, tslib@^2.8.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
+twilio@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/twilio/-/twilio-5.8.0.tgz#9e63688056ca5ad0f5e9ea1816d1398e5d6dff98"
+  integrity sha512-aJLBvI7ODLmFHI7ZYLBiMZKIdHuF9PrPeRM/GBMDg/AAzGXs4V8gEnNPHyTVThK0/8J48YHSqXMlQ+WJR5nxoQ==
+  dependencies:
+    axios "^1.11.0"
+    dayjs "^1.11.9"
+    https-proxy-agent "^5.0.0"
+    jsonwebtoken "^9.0.2"
+    qs "^6.9.4"
+    scmp "^2.1.0"
+    xmlbuilder "^13.0.2"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
@@ -6209,6 +6272,11 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+xmlbuilder@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-13.0.2.tgz#02ae33614b6a047d1c32b5389c1fdacb2bce47a7"
+  integrity sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==
 
 xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
флоу реєстрації з підтвердженням телефону працює:

Флоу реєстрації:

POST /auth/register — створює користувача з isPhoneValidated: false

POST /auth/phone/send — надсилає OTP на номер телефону

POST /auth/phone/verify — перевіряє код і встановлює isPhoneValidated: true

POST /auth/login — перевіряє, що телефон підтверджено, перед авторизацією

Зміни:

✅ Реєстрація більше не авторизує відразу, вимагає підтвердження телефону

✅ Логін перевіряє isPhoneValidated перед авторизацією

✅ Верифікація OTP оновлює isPhoneValidated: true

✅ Додано перевірку унікальності номера телефону під час реєстрації

У мок-режимі код OTP завжди 000000.