### PR TITLE
updaited  Auth Controlle, Users Controller,  Products Controller, Cat…

### DIFF
--- a/src/entities/product.entity.ts
+++ b/src/entities/product.entity.ts
@@ -7,24 +7,23 @@ import { Review } from "./review.entity";
 
 @Entity("products")
 export class Product {
+  @ApiProperty({ description: "Unique identifier", format: "uuid" })
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
-  // @ApiProperty({ description: "Seller of the product" })
   @ManyToOne(() => Seller, seller => seller.products)
   @JoinColumn({ name: "sellerId" })
   seller: Seller;
 
-  @ApiProperty({ description: "Unique identifier", format: "uuid" })
+  @ApiProperty({ description: "Seller ID", format: "uuid", example: "181fe998-8066-41e1-989b-71cd9a085a55" })
   @Column()
   sellerId: string;
 
-  @ApiProperty({ description: "Subcategory of the product" })
   @ManyToOne(() => Subcategory, subcategory => subcategory.products, { onDelete: "SET NULL" })
   @JoinColumn({ name: "subcategoryId" })
   subcategory: Subcategory;
 
-  @ApiProperty({ description: "Subcategory ID", format: "uuid" })
+  @ApiProperty({ description: "Subcategory ID", format: "uuid", example: "181fe998-8066-41e1-989b-71cd9a085a55" })
   @Column()
   subcategoryId: string;
 

--- a/src/entities/seller.entity.ts
+++ b/src/entities/seller.entity.ts
@@ -7,12 +7,14 @@ import {
   OneToMany,
   PrimaryGeneratedColumn
 } from "typeorm";
+import { ApiProperty } from "@nestjs/swagger";
 import { User } from "./user.entity";
 import { Product } from "./product.entity";
 import { Review } from "./review.entity";
 
 @Entity("sellers")
 export class Seller {
+  @ApiProperty({ format: "uuid", description: "Unique identifier for the seller" })
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
@@ -20,24 +22,31 @@ export class Seller {
   @JoinColumn({ name: "userId" })
   user: User;
 
+  @ApiProperty({ description: "User ID of the seller", format: "uuid", example: "181fe998-8066-41e1-989b-71cd9a085a55" })
   @Column()
   userId: string;
 
+  @ApiProperty({ description: "Name of the shop", example: "My Amazing Shop" })
   @Column()
   shopName: string;
 
+  @ApiProperty({ required: false, description: "Legal address of the seller", example: "123 Main St, Kiev, Ukraine" })
   @Column({ nullable: true })
   legalAddress?: string;
 
+  @ApiProperty({ required: false, description: "Tax identification number", example: "12345678901" })
   @Column({ nullable: true })
   taxId?: string;
 
+  @ApiProperty({ required: false, description: "Phone number", example: "+380991234567" })
   @Column({ nullable: true })
   phone?: string;
 
+  @ApiProperty({ required: false, description: "Description of the seller's business", example: "We sell quality products" })
   @Column({ nullable: true })
   description?: string;
 
+  @ApiProperty({ description: "Date when seller was created" })
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/entities/subcategory.entity.ts
+++ b/src/entities/subcategory.entity.ts
@@ -13,20 +13,14 @@ export class Subcategory {
   @Column()
   name: string;
 
-  @ApiProperty({ description: "Parent category" })
   @ManyToOne(() => Category, category => category.subcategories, { onDelete: "CASCADE" })
   @JoinColumn({ name: "categoryId" })
   category: Category;
 
-  @ApiProperty({ description: "Category ID", format: "uuid" })
+  @ApiProperty({ description: "Category ID", format: "uuid", example: "181fe998-8066-41e1-989b-71cd9a085a55" })
   @Column()
   categoryId: string;
 
-  @ApiProperty({
-    description: "Parent subcategory (for nesting)",
-    required: false,
-    type: () => Subcategory
-  })
   @ManyToOne(() => Subcategory, subcategory => subcategory.children, {
     nullable: true,
     onDelete: "CASCADE"
@@ -34,15 +28,13 @@ export class Subcategory {
   @JoinColumn({ name: "parentSubcategoryId" })
   parentSubcategory?: Subcategory;
 
-  @ApiProperty({ description: "Parent subcategory ID", format: "uuid", required: false })
+  @ApiProperty({ description: "Parent subcategory ID", format: "uuid", required: false, example: "181fe998-8066-41e1-989b-71cd9a085a55" })
   @Column({ nullable: true })
   parentSubcategoryId?: string;
 
-  @ApiProperty({ description: "List of child subcategories", type: () => [Subcategory] })
   @OneToMany(() => Subcategory, subcategory => subcategory.parentSubcategory)
   children: Subcategory[];
 
-  @ApiProperty({ description: "List of products in this subcategory", type: () => [Product] })
   @OneToMany(() => Product, product => product.subcategory)
   products: Product[];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,14 @@ async function bootstrap() {
     logger: ["error", "warn", "log", "debug"]
   });
 
+  // Enable CORS
+  app.enableCors({
+    origin: true, // Allow all origins during development
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-request-id', 'Accept', 'Origin', 'X-Requested-With'],
+  });
+
   app.use(cookieParcer());
 
   app.useGlobalPipes(new ValidationPipe());
@@ -18,11 +26,41 @@ async function bootstrap() {
 
   const config = new DocumentBuilder()
     .setTitle("MarketPlace API")
-    .setDescription("API docs")
-    .addBearerAuth()
+    .setDescription("API documentation for MarketPlace Backend")
+    .setVersion("1.0")
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'JWT',
+        description: 'Enter JWT token',
+        in: 'header',
+      },
+      'JWT-auth'
+    )
+    .addServer('http://localhost:3000', 'Development server')
     .build();
+    
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup("/docs", app, document);
+  SwaggerModule.setup("/docs", app, document, {
+    customSiteTitle: 'MarketPlace API Documentation',
+    swaggerOptions: {
+      persistAuthorization: true,
+      displayRequestDuration: true,
+      docExpansion: 'none',
+      filter: true,
+      showExtensions: true,
+      showCommonExtensions: true,
+      tryItOutEnabled: true,
+      requestInterceptor: (request) => {
+        request.headers['Access-Control-Allow-Origin'] = '*';
+        request.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, PATCH, DELETE, OPTIONS';
+        request.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization';
+        return request;
+      },
+    },
+  });
 
   const port = process.env.PORT ?? 3000;
   await app.listen(port, "::");

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -13,7 +13,17 @@ import { AuthService } from "./auth.service";
 import { CreateUserDto } from "src/modules/users/dtos/create-user.dto";
 
 import { ChangePasswordDto } from "./dtos/change-password.dto";
-import { ApiBody, ApiOperation } from "@nestjs/swagger";
+import { 
+  ApiBody, 
+  ApiOperation, 
+  ApiResponse, 
+  ApiBadRequestResponse, 
+  ApiCreatedResponse, 
+  ApiOkResponse, 
+  ApiUnauthorizedResponse,
+  ApiBearerAuth,
+  ApiTags 
+} from "@nestjs/swagger";
 
 import type { Request, Response } from "express";
 import { RequestWithUser } from "../../common/types";
@@ -26,17 +36,90 @@ import { LoginUserDto } from "../users/dtos/login-user.dto";
 
 // import { LocalAuthGuard } from "./local-auth.guard";
 
+@ApiTags('Auth')
 @Controller("auth")
 export class AuthController {
   constructor(private authService: AuthService) {}
 
   @ApiOperation({ summary: "Register new user" })
+  @ApiCreatedResponse({ 
+    description: 'User successfully registered',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid', example: '181fe998-8066-41e1-989b-71cd9a085a55' },
+        firstName: { type: 'string', example: 'Василь' },
+        email: { type: 'string', example: 'basilbasilyuk@mail.gov' },
+        phone: { type: 'string', example: '+380991234567' },
+        isPhoneValidated: { type: 'boolean', example: false },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error or user already exists',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { 
+          oneOf: [
+            { type: 'string', example: 'User with this email already exists' },
+            { type: 'array', items: { type: 'string' }, example: ['email must be an email', 'password must be longer than or equal to 6 characters'] }
+          ]
+        },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
   @Post("register")
   register(@Res({ passthrough: true }) res: Response, @Body() createUserDto: CreateUserDto) {
     return this.authService.register(res, createUserDto);
   }
 
   @ApiOperation({ summary: "Login existing user" })
+  @ApiOkResponse({
+    description: 'User successfully logged in',
+    schema: {
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: '181fe998-8066-41e1-989b-71cd9a085a55' },
+            firstName: { type: 'string', example: 'Василь' },
+            email: { type: 'string', example: 'basilbasilyuk@mail.gov' },
+            phone: { type: 'string', example: '+380991234567' },
+            isPhoneValidated: { type: 'boolean', example: false }
+          }
+        },
+        accessToken: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' }
+      }
+    }
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Invalid credentials',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Invalid credentials' },
+        error: { type: 'string', example: 'Unauthorized' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' }, example: ['email must be an email'] },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
   @HttpCode(HttpStatus.OK)
   //@UseGuards(LocalAuthGuard)
   @Post("login")
@@ -46,6 +129,27 @@ export class AuthController {
   }
 
   @ApiOperation({ summary: "Refresh user's credentions when access token expired" })
+  @ApiOkResponse({
+    description: 'Tokens successfully refreshed',
+    schema: {
+      type: 'object',
+      properties: {
+        accessToken: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' }
+      }
+    }
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Invalid refresh token',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Invalid refresh token' },
+        error: { type: 'string', example: 'Unauthorized' }
+      }
+    }
+  })
+  @ApiBearerAuth('JWT-auth')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtRefreshGuard)
   @Post("refresh")
@@ -63,6 +167,43 @@ export class AuthController {
       }
     }
   })
+  @ApiOkResponse({
+    description: 'Password successfully changed',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', example: 'Password changed successfully' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid current password or validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { 
+          oneOf: [
+            { type: 'string', example: 'Current password is incorrect' },
+            { type: 'array', items: { type: 'string' }, example: ['newPassword must be longer than or equal to 6 characters'] }
+          ]
+        },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Unauthorized' },
+        error: { type: 'string', example: 'Unauthorized' }
+      }
+    }
+  })
+  @ApiBearerAuth('JWT-auth')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @Patch("change-password")

--- a/src/modules/auth/dtos/change-password.dto.ts
+++ b/src/modules/auth/dtos/change-password.dto.ts
@@ -1,9 +1,12 @@
 import { IsString, MinLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ChangePasswordDto {
+  @ApiProperty({ description: "Current password", example: "oldpassword" })
   @IsString()
   currentPassword: string;
 
+  @ApiProperty({ description: "New password", example: "newpassword", minLength: 6 })
   @IsString()
   @MinLength(6)
   newPassword: string;

--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -2,38 +2,149 @@ import { Controller, Get, Post, Body, Patch, Param, Delete } from "@nestjs/commo
 import { CategoriesService } from "./categories.service";
 import { CreateCategoryDto } from "./dto/create-category.dto";
 import { UpdateCategoryDto } from "./dto/update-category.dto";
-import { ApiOperation } from "@nestjs/swagger";
+import { Category } from "../../entities/category.entity";
+import { 
+  ApiOperation, 
+  ApiTags,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiParam,
+  ApiNoContentResponse
+} from "@nestjs/swagger";
 
+@ApiTags('Categories')
 @Controller("categories")
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Post()
   @ApiOperation({ summary: "Create new category" })
+  @ApiCreatedResponse({ 
+    description: 'Category successfully created',
+    type: Category 
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error or category already exists',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { 
+          oneOf: [
+            { type: 'string', example: 'Category with this name already exists' },
+            { type: 'array', items: { type: 'string' }, example: ['name should not be empty'] }
+          ]
+        },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
   create(@Body() createCategoryDto: CreateCategoryDto) {
     return this.categoriesService.create(createCategoryDto);
   }
 
   @Get()
   @ApiOperation({ summary: "Get all categories with subcategories" })
+  @ApiOkResponse({ 
+    description: 'List of all categories with their subcategories',
+    type: [Category] 
+  })
   findAll() {
     return this.categoriesService.findAll();
   }
 
   @Get(":id")
   @ApiOperation({ summary: "Get category by id" })
+  @ApiOkResponse({ 
+    description: 'Category found successfully',
+    type: Category 
+  })
+  @ApiNotFoundResponse({
+    description: 'Category not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Category not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   findOne(@Param("id") id: string) {
     return this.categoriesService.findOne(id);
   }
 
   @Patch(":id")
   @ApiOperation({ summary: "Update category by id" })
+  @ApiOkResponse({ 
+    description: 'Category updated successfully',
+    type: Category 
+  })
+  @ApiNotFoundResponse({
+    description: 'Category not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Category not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' }, example: ['name should not be empty'] },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   update(@Param("id") id: string, @Body() updateCategoryDto: UpdateCategoryDto) {
     return this.categoriesService.update(id, updateCategoryDto);
   }
 
   @Delete(":id")
   @ApiOperation({ summary: "Delete category by id" })
+  @ApiNoContentResponse({ 
+    description: 'Category deleted successfully' 
+  })
+  @ApiNotFoundResponse({
+    description: 'Category not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Category not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Category ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   remove(@Param("id") id: string) {
     return this.categoriesService.remove(id);
   }

--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -2,47 +2,156 @@ import { Controller, Get, Post, Body, Patch, Param, Delete } from "@nestjs/commo
 import { ProductsService } from "./products.service";
 import { CreateProductDto } from "./dto/create-product.dto";
 import { UpdateProductDto } from "./dto/update-product.dto";
-import { ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { 
+  ApiOperation, 
+  ApiResponse, 
+  ApiTags,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiParam,
+  ApiNoContentResponse
+} from "@nestjs/swagger";
 import { Product } from "src/entities/product.entity";
 
+@ApiTags('Products')
 @Controller("products")
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
 
   @Post()
   @ApiOperation({ summary: "Create a new product" })
-  @ApiResponse({ status: 201, type: Product })
-  @ApiResponse({ status: 404, description: "Seller or subcategory not found" })
+  @ApiCreatedResponse({ 
+    description: 'Product successfully created',
+    type: Product 
+  })
+  @ApiNotFoundResponse({
+    description: 'Seller or subcategory not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Seller or subcategory not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' }, example: ['name should not be empty', 'price must be a number'] },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
   create(@Body() createProductDto: CreateProductDto) {
     return this.productsService.create(createProductDto);
   }
 
   @Get()
   @ApiOperation({ summary: "Get all products with seller and subcategory" })
-  @ApiResponse({ status: 200, type: [Product] })
+  @ApiOkResponse({ 
+    description: 'List of all products',
+    type: [Product] 
+  })
   findAll() {
     return this.productsService.findAll();
   }
 
   @Get(":id")
   @ApiOperation({ summary: "Get product by ID" })
-  @ApiResponse({ status: 200, type: Product })
-  @ApiResponse({ status: 404, description: "Product not found" })
+  @ApiOkResponse({ 
+    description: 'Product found successfully',
+    type: Product 
+  })
+  @ApiNotFoundResponse({
+    description: 'Product not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Product not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Product ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   findOne(@Param("id") id: string) {
     return this.productsService.findOne(id);
   }
 
   @Patch(":id")
   @ApiOperation({ summary: "Update product by ID" })
-  @ApiResponse({ status: 200, type: Product })
-  @ApiResponse({ status: 404, description: "Product not found" })
+  @ApiOkResponse({ 
+    description: 'Product updated successfully',
+    type: Product 
+  })
+  @ApiNotFoundResponse({
+    description: 'Product not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Product not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' }, example: ['price must be a number'] },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Product ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   update(@Param("id") id: string, @Body() updateProductDto: UpdateProductDto) {
     return this.productsService.update(id, updateProductDto);
   }
 
   @Delete(":id")
   @ApiOperation({ summary: "Delete product by ID" })
-  @ApiResponse({ status: 204 })
+  @ApiNoContentResponse({ 
+    description: 'Product deleted successfully' 
+  })
+  @ApiNotFoundResponse({
+    description: 'Product not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Product not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Product ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   remove(@Param("id") id: string) {
     return this.productsService.remove(id);
   }

--- a/src/modules/sellers/sellers.controller.ts
+++ b/src/modules/sellers/sellers.controller.ts
@@ -2,31 +2,139 @@ import { Controller, Get, Post, Body, Patch, Param, Delete } from "@nestjs/commo
 import { SellersService } from "./sellers.service";
 import { CreateSellerDto } from "./dto/create-seller.dto";
 import { UpdateSellerDto } from "./dto/update-seller.dto";
-import { ApiOperation } from "@nestjs/swagger";
+import { Seller } from "../../entities/seller.entity";
+import { 
+  ApiOperation, 
+  ApiTags,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiParam,
+  ApiNoContentResponse
+} from "@nestjs/swagger";
 
+@ApiTags('Sellers')
 @Controller("sellers")
 export class SellersController {
   constructor(private readonly sellersService: SellersService) {}
 
   @Post()
-  @ApiOperation({ summary: "Create seller", description: "In progress" })
+  @ApiOperation({ summary: "Create seller" })
+  @ApiCreatedResponse({ 
+    description: 'Seller successfully created',
+    type: Seller 
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error or seller already exists',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { 
+          oneOf: [
+            { type: 'string', example: 'Shop name already exists' },
+            { type: 'array', items: { type: 'string' }, example: ['shopName should not be empty', 'userId must be a UUID'] }
+          ]
+        },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
   create(@Body() createSellerDto: CreateSellerDto) {
     return this.sellersService.create(createSellerDto);
   }
 
   @Get("/:id")
-  @ApiOperation({ summary: "Get seller by Id", description: "In progress" })
+  @ApiOperation({ summary: "Get seller by Id" })
+  @ApiOkResponse({ 
+    description: 'Seller found successfully',
+    type: Seller 
+  })
+  @ApiNotFoundResponse({
+    description: 'Seller not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Seller not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Seller ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   findOne(@Param("id") id: string) {
     return this.sellersService.findOne(id);
   }
 
   @Patch(":id")
-  @ApiOperation({ summary: "Update seller", description: "In progress" })
+  @ApiOperation({ summary: "Update seller" })
+  @ApiOkResponse({ 
+    description: 'Seller updated successfully',
+    type: Seller 
+  })
+  @ApiNotFoundResponse({
+    description: 'Seller not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Seller not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' }, example: ['shopName should not be empty'] },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Seller ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   update(@Param("id") id: string, @Body() updateSellerDto: UpdateSellerDto) {
     return this.sellersService.update(id, updateSellerDto);
   }
 
   @Delete(":id")
+  @ApiOperation({ summary: "Delete seller by ID" })
+  @ApiNoContentResponse({ 
+    description: 'Seller deleted successfully' 
+  })
+  @ApiNotFoundResponse({
+    description: 'Seller not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'Seller not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Seller ID',
+    type: 'string',
+    format: 'uuid',
+    example: '181fe998-8066-41e1-989b-71cd9a085a55'
+  })
   remove(@Param("id") id: string) {
     return this.sellersService.remove(id);
   }

--- a/src/modules/users/dtos/create-user.dto.ts
+++ b/src/modules/users/dtos/create-user.dto.ts
@@ -26,6 +26,7 @@ export class CreateUserDto {
   @Length(6, 20)
   password: string;
 
+  @ApiProperty({ required: false, description: "Whether user's phone is validated", example: false })
   @IsOptional()
   @IsBoolean()
   isPhoneValidated?: boolean;

--- a/src/modules/users/dtos/update-user.dto.ts
+++ b/src/modules/users/dtos/update-user.dto.ts
@@ -33,10 +33,12 @@ export class UpdateUsersDto {
   @IsDate()
   birthDay?: Date;
 
+  @ApiPropertyOptional({ description: "User's password", example: "mysecretword" })
   @IsOptional()
   @IsString()
   password?: string;
 
+  @ApiPropertyOptional({ description: "Whether user's phone is validated", example: false })
   @IsOptional()
   @IsBoolean()
   isPhoneValidated?: boolean;

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -11,16 +11,63 @@ import {
 import { UsersService } from "./users.service";
 import { UpdateUsersDto } from "./dtos/update-user.dto";
 import { ChangePhoneDto } from "./dtos/change-phone.dto";
-import { ApiBearerAuth, ApiOperation, ApiParam } from "@nestjs/swagger";
+import { 
+  ApiBearerAuth, 
+  ApiOperation, 
+  ApiParam, 
+  ApiTags,
+  ApiOkResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiUnauthorizedResponse
+} from "@nestjs/swagger";
 import { JwtAuthGuard } from "../auth/guards/jwt-auth.guard";
 
+@ApiTags('Users')
 @Controller("users")
 export class UsersController {
   constructor(private UsersService: UsersService) {}
 
   @Get("/:id")
   @ApiOperation({ summary: "Get user by ID" })
-  @ApiBearerAuth()
+  @ApiOkResponse({
+    description: 'User found successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid', example: '181fe998-8066-41e1-989b-71cd9a085a55' },
+        firstName: { type: 'string', example: 'Василь' },
+        email: { type: 'string', example: 'basilbasilyuk@mail.gov' },
+        phone: { type: 'string', example: '+380991234567' },
+        isPhoneValidated: { type: 'boolean', example: false },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' }
+      }
+    }
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'User not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Unauthorized' },
+        error: { type: 'string', example: 'Unauthorized' }
+      }
+    }
+  })
+  @ApiBearerAuth('JWT-auth')
   @ApiParam({
     name: "id",
     description: "The unique user's ID",
@@ -41,13 +88,44 @@ export class UsersController {
 
   @Delete(":id")
   @ApiOperation({ summary: "Delete user" })
+  @ApiOkResponse({
+    description: 'User deleted successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        message: { type: 'string', example: 'User deleted successfully' }
+      }
+    }
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'User not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Unauthorized' },
+        error: { type: 'string', example: 'Unauthorized' }
+      }
+    }
+  })
   @ApiParam({
     name: "id",
     description: "The unique user's ID",
     type: String,
     example: "181fe998-8066-41e1-989b-71cd9a085a55"
   })
-  @ApiBearerAuth()
+  @ApiBearerAuth('JWT-auth')
   @UseGuards(JwtAuthGuard)
   async delete(@Param("id") id: string) {
     await this.UsersService.delete(id);
@@ -55,26 +133,122 @@ export class UsersController {
 
   @Patch(":id")
   @ApiOperation({ summary: "Update a specific user" })
+  @ApiOkResponse({
+    description: 'User updated successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid', example: '181fe998-8066-41e1-989b-71cd9a085a55' },
+        firstName: { type: 'string', example: 'Василь' },
+        email: { type: 'string', example: 'basilbasilyuk@mail.gov' },
+        phone: { type: 'string', example: '+380991234567' },
+        isPhoneValidated: { type: 'boolean', example: false },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' }
+      }
+    }
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'User not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' }, example: ['email must be an email'] },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Unauthorized' },
+        error: { type: 'string', example: 'Unauthorized' }
+      }
+    }
+  })
   @ApiParam({
     name: "id",
     description: "The unique user's ID",
     type: String,
     example: "181fe998-8066-41e1-989b-71cd9a085a55"
   })
-  @ApiBearerAuth()
+  @ApiBearerAuth('JWT-auth')
   @UseGuards(JwtAuthGuard)
   async updateUser(@Param("id") id: string, @Body() updateUserDto: UpdateUsersDto) {
     return await this.UsersService.update(id, updateUserDto);
   }
 
   @ApiOperation({ summary: "Change user's phone number" })
+  @ApiOkResponse({
+    description: 'Phone number changed successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid', example: '181fe998-8066-41e1-989b-71cd9a085a55' },
+        firstName: { type: 'string', example: 'Василь' },
+        email: { type: 'string', example: 'basilbasilyuk@mail.gov' },
+        phone: { type: 'string', example: '+380501234567' },
+        isPhoneValidated: { type: 'boolean', example: false },
+        createdAt: { type: 'string', format: 'date-time' },
+        updatedAt: { type: 'string', format: 'date-time' }
+      }
+    }
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 404 },
+        message: { type: 'string', example: 'User not found' },
+        error: { type: 'string', example: 'Not Found' }
+      }
+    }
+  })
+  @ApiBadRequestResponse({
+    description: 'Validation error',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 400 },
+        message: { type: 'array', items: { type: 'string' }, example: ['newPhone must be in international format'] },
+        error: { type: 'string', example: 'Bad Request' }
+      }
+    }
+  })
+  @ApiUnauthorizedResponse({
+    description: 'User not authenticated',
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: { type: 'number', example: 401 },
+        message: { type: 'string', example: 'Unauthorized' },
+        error: { type: 'string', example: 'Unauthorized' }
+      }
+    }
+  })
   @ApiParam({
     name: "id",
     description: "The unique user's ID",
     type: String,
     example: "181fe998-8066-41e1-989b-71cd9a085a55"
   })
-  @ApiBearerAuth()
+  @ApiBearerAuth('JWT-auth')
   @UseGuards(JwtAuthGuard)
   @Patch(":id/change-phone")
   async changePhone(@Param("id") id: string, @Body() changePhoneDto: ChangePhoneDto) {


### PR DESCRIPTION
…egories Controller, Sellers Controller,  DTO Updates
 Доповнила Swagger документацію для всіх контролерів. Ось що було зроблено:

  Оновлення контролерів:

  Auth Controller:

  - Додано детальні описи відповідей для register, login, refresh та change-password
  - Додано приклади помилок (400, 401)
  - Додано схеми тіла запитів та відповідей

  Users Controller:
  - Додано описи для всіх методів (GET, PATCH, DELETE)
  - Додано обробку помилок 404, 400, 401
  - Додано параметри для UUID

  Products Controller:
  - Додано повну документацію для CRUD операцій
  - Додано описи помилок та успішних відповідей
  - Додано параметри для Product ID

  Categories Controller:
  - Додано документацію для всіх методів
  - Додано обробку помилок та успішних відповідей
  - Імпортовано Category entity

  Sellers Controller:
  - Додано повну документацію
  - Додано ApiProperty до Seller entity
  - Додано обробку всіх типових помилок

  DTO Updates:
  - Доповнено ApiProperty для всіх полів
  - Додано приклади та описи
  - Оновлено ChangePasswordDto

  Тепер Swagger документація містить повні описи:
  - Тіл запитів та відповідей
  - Кодів помилок з поясненнями
  - Прикладів використання
  - Параметрів запитів
  - Схем валідації

  1. Додано CORS підтримку в main.ts:
    - Дозволено всі origins для розробки (origin: true)
    - Додано всі необхідні HTTP методи
    - Додано всі потрібні заголовки
  2. Оновлено конфігурацію Swagger:
    - Покращено налаштування документації
    - Додано server URL для правильної роботи
    - Додано requestInterceptor для обробки CORS заголовків
    - Оновлено Bearer Auth конфігурацію
  3. Оновлено декоратори в контролерах:
    - Змінено @ApiBearerAuth() на @ApiBearerAuth('JWT-auth')

ERROR
 Що було виправлено:
  1. Seller Entity (src/entities/seller.entity.ts):

  - Прибрала @ApiProperty з user relation
  - Залишила тільки userId з ApiProperty

  2. Product Entity (src/entities/product.entity.ts):

  - Прибрала @ApiProperty з seller та subcategory relations
  - Залишила тільки sellerId та subcategoryId з ApiProperty
  - Додала ApiProperty до id поля

  3. Subcategory Entity (src/entities/subcategory.entity.ts):

  - Прибрала @ApiProperty з усіх relation полів (category, parentSubcategory, children, products)
  - Залишив тільки ID поля з ApiProperty

ERROR
  Принцип вирішення:
  - Relations (OneToMany, ManyToOne) НЕ повинні мати @ApiProperty декораторів
  - Тільки ID поля та прості поля повинні мати @ApiProperty
  - Це запобігає циклічним залежностям в Swagger схемах
  Тепер сервер повинен запуститися без помилок циклічних залежностей. Swagger документація буде показувати тільки
  ID посилання замість повних об'єктів, що є правильним підходом для API документації.
